### PR TITLE
Update constraint on diagrams-lib

### DIFF
--- a/diagrams-postscript.cabal
+++ b/diagrams-postscript.cabal
@@ -37,7 +37,7 @@ Library
                        dlist >= 0.5 && < 0.8,
                        vector-space >= 0.7.7 && < 0.9,
                        diagrams-core >= 1.0 && < 1.3,
-                       diagrams-lib >= 1.0.1 && < 1.3,
+                       diagrams-lib >= 1.2 && < 1.3,
                        data-default-class < 0.1,
                        split >= 0.1.2 && < 0.3,
                        monoid-extras >= 0.3 && < 0.4,


### PR DESCRIPTION
 Update constraint on diagrams-lib, as we now depend on Diagrams.TwoD.Attributes which was introduced in version 1.2
