### PR TITLE
Bump lens upper version bounds

### DIFF
--- a/diagrams-postscript.cabal
+++ b/diagrams-postscript.cabal
@@ -42,7 +42,7 @@ Library
                        split >= 0.1.2 && < 0.3,
                        monoid-extras >= 0.3 && < 0.4,
                        semigroups >= 0.3.4 && < 0.16,
-                       lens >= 4.0 && < 4.5,
+                       lens >= 4.0 && < 4.6,
                        containers >= 0.3 && < 0.6,
                        hashable >= 1.1 && < 1.3
   if impl(ghc < 7.6)


### PR DESCRIPTION
Allow `diagrams-postscript` to use the latest version of `lens` (4.5).
