### PR TITLE
Bump dlist upper bound to 0.9

### DIFF
--- a/diagrams-postscript.cabal
+++ b/diagrams-postscript.cabal
@@ -37,7 +37,7 @@ Library
   Build-depends:       base >= 4.2 && < 4.10,
                        mtl >= 2.0 && < 2.3,
                        filepath,
-                       dlist >= 0.5 && < 0.8,
+                       dlist >= 0.5 && < 0.9,
                        diagrams-core >= 1.3 && < 1.4,
                        diagrams-lib >= 1.3 && < 1.4,
                        data-default-class < 0.2,


### PR DESCRIPTION
I just released [`dlist-0.8`](https://github.com/spl/dlist/releases/tag/v0.8). I didn't test this change to `diagrams-postscript`, but I don't think it will be break anything.