### PR TITLE
Allow in-memory rendering

### DIFF
--- a/CHANGES.markdown
+++ b/CHANGES.markdown
@@ -1,3 +1,7 @@
+## [1.5](https://github.com/diagrams/diagrams-postscript/tree/v1.5) (TBA)
+
+  - Make `Result Postscript V2 Double = Builder`, allowing rendering in-memory.
+
 ## [1.4](https://github.com/diagrams/diagrams-postscript/tree/v1.4) (2016-10-26)
 
 No significant changes, bumping version to correspond to diagrams 1.4

--- a/diagrams-postscript.cabal
+++ b/diagrams-postscript.cabal
@@ -1,5 +1,5 @@
 Name:                diagrams-postscript
-Version:             1.4
+Version:             1.5
 Synopsis:            Postscript backend for diagrams drawing EDSL
 Description:         This package provides a modular backend for rendering
                      diagrams created with the diagrams EDSL using Postscript.
@@ -35,9 +35,9 @@ Library
                        Graphics.Rendering.Postscript
   Hs-source-dirs:      src
   Build-depends:       base >= 4.2 && < 4.10,
+                       bytestring >= 0.9 && <0.11,
                        mtl >= 2.0 && < 2.3,
                        filepath,
-                       dlist >= 0.5 && < 0.9,
                        diagrams-core >= 1.3 && < 1.5,
                        diagrams-lib >= 1.3 && < 1.5,
                        data-default-class < 0.2,

--- a/src/Diagrams/Backend/Postscript.hs
+++ b/src/Diagrams/Backend/Postscript.hs
@@ -64,6 +64,8 @@ import qualified Control.Monad.StateStack         as SS
 import           Control.Monad.Trans              (lift)
 import           Data.Maybe                       (catMaybes, isJust)
 
+import qualified Data.ByteString.Builder          as B
+
 import qualified Data.Foldable                    as F
 import           Data.Hashable                    (Hashable (..))
 import           Data.Tree
@@ -128,7 +130,7 @@ instance Monoid (Render Postscript V2 Double) where
 
 instance Backend Postscript V2 Double where
   data Render  Postscript V2 Double = C (RenderM ())
-  type Result  Postscript V2 Double = IO ()
+  type Result  Postscript V2 Double = B.Builder
   data Options Postscript V2 Double = PostscriptOptions
           { _psfileName     :: String       -- ^ the name of the file you want generated
           , _psSizeSpec     :: SizeSpec V2 Double   -- ^ the requested size of the output
@@ -137,7 +139,7 @@ instance Backend Postscript V2 Double where
     deriving (Show)
 
   renderRTree _ opts t =
-    let surfaceF surface = C.renderWith surface r
+    let surfaceF surface = fst (C.renderBuilder surface r)
         V2 w h = specToSize 100 (opts^.psSizeSpec)
         r = runRenderM . runC . toRender $ t
     in case opts^.psOutputFormat of

--- a/src/Diagrams/Backend/Postscript/CmdLine.hs
+++ b/src/Diagrams/Backend/Postscript/CmdLine.hs
@@ -72,6 +72,9 @@ module Diagrams.Backend.Postscript.CmdLine
 
       ) where
 
+import qualified Data.ByteString.Builder     as B
+import           System.IO                   (IOMode (..), hPutStr, withFile)
+
 import           Diagrams.Backend.CmdLine
 import           Diagrams.Backend.Postscript
 import           Diagrams.Prelude            hiding (height, interval, option,
@@ -165,7 +168,10 @@ renderDias' :: [QDiagram Postscript V2 Double Any] -> Options Postscript V2 Doub
 renderDias' ds o = renderDias o ds >> return ()
 
 renderDia' :: QDiagram Postscript V2 Double Any -> Options Postscript V2 Double -> IO ()
-renderDia' d o = renderDia Postscript o d >> return ()
+renderDia' d o = do
+  let b = renderDia Postscript o d
+  withFile (o ^. psfileName) WriteMode $ \h -> B.hPutBuilder h b
+
 
 
 -- | @multiMain@ is like 'defaultMain', except instead of a single


### PR DESCRIPTION
Resolves #6 

- I made `Result .... = B.Builder`, it could be lazy bytestring too, or we could re-export `toLazyBytestring` from `Diagrams.Backend.Postscript` (i like the last option most).
- Should I remove `_psfileName` field, then this will be more breaking change