### PR TITLE
Fix the GHC 8.2 build

### DIFF
--- a/src/Diagrams/Backend/Postscript/CMYK.hs
+++ b/src/Diagrams/Backend/Postscript/CMYK.hs
@@ -52,7 +52,6 @@ import           Graphics.Rendering.Postscript(CMYK(..))
 --   is that of 'Last'.
 newtype LineColorCMYK = LineColorCMYK (Last CMYK)
   deriving (Typeable, Semigroup)
-instance AttributeClass LineColorCMYK
 
 instance Default LineColorCMYK where
     def = LineColorCMYK (Last (CMYK 0 0 0 1))
@@ -96,7 +95,6 @@ lcCMYK = lineColorCMYK
 --   is that of 'Last'.
 newtype FillColorCMYK = FillColorCMYK (Recommend (Last CMYK))
   deriving (Typeable, Semigroup)
-instance AttributeClass FillColorCMYK
 
 instance Default FillColorCMYK where
   def = FillColorCMYK (Recommend (Last (CMYK 0 0 0 0)))


### PR DESCRIPTION
Currently, building `diagrams-postscript` against the most recent `diagrams-core` (from master) and GHC 8.2 fails with this error:

```
[2 of 4] Compiling Diagrams.Backend.Postscript.CMYK ( src/Diagrams/Backend/Postscript/CMYK.hs, dist/dist-sandbox-f788eb96/build/Diagrams/Backend/Postscript/CMYK.o )

src/Diagrams/Backend/Postscript/CMYK.hs:55:10: error:
    • Illegal instance for a type synonym
      A class instance must be for a class
    • In the instance declaration for ‘AttributeClass LineColorCMYK’
   |
55 | instance AttributeClass LineColorCMYK
   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^

src/Diagrams/Backend/Postscript/CMYK.hs:99:10: error:
    • Illegal instance for a type synonym
      A class instance must be for a class
    • In the instance declaration for ‘AttributeClass FillColorCMYK’
   |
99 | instance AttributeClass FillColorCMYK
   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

(Using the master version of `diagrams-core` is important here, since on Hackage, [`AttributeClass` is a class](http://hackage.haskell.org/package/diagrams-core-1.4/docs/Diagrams-Core-Style.html#t:AttributeClass), not a type synonym.)

This is because [GHC 8.2 is more conservative](https://ghc.haskell.org/trac/ghc/wiki/Migration/8.2#Instancesforclasssynonymsarenowdisallowed) about allowing type synonyms in the class position of instances. But given that `AttributeClass` is a type synonym for `(Typeable a, Semigroup a)`, and both `LineColorCMYK` and `FillColorCMYK` have `Typeable` and `Semigroup` instances anyway, these `instance AttributeClass ...` declarations are completely redundant, so they can be removed without backwards compatibility issues.