### PR TITLE
Fix bounds on various packages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,9 @@ env:
     - GHCVER=7.6.3 CABALVER=1.18
     - GHCVER=7.8.4 CABALVER=1.18
     - GHCVER=7.10.3 CABALVER=1.22
-    - GHCVER=8.0.1 CABALVER=1.24
+    - GHCVER=8.0.2 CABALVER=1.24
+    - GHCVER=8.2.2 CABALVER=2.0
+    - GHCVER=8.4.2 CABALVER=2.3
     - GHCVER=head CABALVER=head
   global:
     - HEAD_DEPS="diagrams-core diagrams-lib diagrams-solve active monoid-extras statestack dual-tree"

--- a/diagrams-postscript.cabal
+++ b/diagrams-postscript.cabal
@@ -23,7 +23,7 @@ Bug-reports:         http://github.com/diagrams/diagrams-postscript/issues
 Category:            Graphics
 Build-type:          Simple
 Cabal-version:       >=1.10
-Tested-with:         GHC == 7.6.3, GHC == 7.8.4, GHC == 7.10.3, GHC == 8.0.1
+Tested-with:         GHC == 7.6.3, GHC == 7.8.4, GHC == 7.10.3, GHC == 8.0.2, GHC == 8.2.2, GHC == 8.4.2
 Source-repository head
   type:     git
   location: https://github.com/diagrams/diagrams-postscript.git
@@ -34,7 +34,7 @@ Library
                        Diagrams.Backend.Postscript.CmdLine
                        Graphics.Rendering.Postscript
   Hs-source-dirs:      src
-  Build-depends:       base >= 4.2 && < 4.11,
+  Build-depends:       base >= 4.2 && < 4.12,
                        bytestring >= 0.9 && <0.11,
                        mtl >= 2.0 && < 2.3,
                        filepath,
@@ -45,7 +45,7 @@ Library
                        split >= 0.1.2 && < 0.3,
                        monoid-extras >= 0.3 && < 0.5,
                        semigroups >= 0.3.4 && < 0.19,
-                       lens >= 4.0 && < 4.16,
+                       lens >= 4.0 && < 4.17,
                        containers >= 0.3 && < 0.6,
                        hashable >= 1.1 && < 1.3
   if impl(ghc < 7.6)

--- a/diagrams-postscript.cabal
+++ b/diagrams-postscript.cabal
@@ -37,7 +37,6 @@ Library
   Build-depends:       base >= 4.2 && < 4.12,
                        bytestring >= 0.9 && <0.11,
                        mtl >= 2.0 && < 2.3,
-                       filepath,
                        diagrams-core >= 1.3 && < 1.5,
                        diagrams-lib >= 1.3 && < 1.5,
                        data-default-class < 0.2,


### PR DESCRIPTION
This allows build with a more modern version of `lens` and allows a more modern version of `base`. 