### PR TITLE
Support GHC 8.8

### DIFF
--- a/diagrams-postscript.cabal
+++ b/diagrams-postscript.cabal
@@ -34,7 +34,7 @@ Library
                        Diagrams.Backend.Postscript.CmdLine
                        Graphics.Rendering.Postscript
   Hs-source-dirs:      src
-  Build-depends:       base >= 4.2 && < 4.13,
+  Build-depends:       base >= 4.2 && < 4.14,
                        bytestring >= 0.9 && <0.11,
                        mtl >= 2.0 && < 2.3,
                        diagrams-core >= 1.3 && < 1.5,
@@ -43,7 +43,7 @@ Library
                        statestack >= 0.2 && < 0.3,
                        split >= 0.1.2 && < 0.3,
                        monoid-extras >= 0.3 && < 0.6,
-                       semigroups >= 0.3.4 && < 0.19,
+                       semigroups >= 0.3.4 && < 0.20,
                        lens >= 4.0 && < 4.18,
                        containers >= 0.3 && < 0.7,
                        hashable >= 1.1 && < 1.3


### PR DESCRIPTION
Pardon an automatically-posted pull request; this is a part of [Operation Vanguard](https://github.com/haskell-vanguard/haskell-vanguard). Note that this does not guarantee that tests and benchmarks are buildable.