### PR TITLE
Allow mtl-2.3

### DIFF
--- a/diagrams-postscript.cabal
+++ b/diagrams-postscript.cabal
@@ -36,7 +36,7 @@ Library
   Hs-source-dirs:      src
   Build-depends:       base >= 4.8 && < 4.18,
                        bytestring >= 0.9 && <0.12,
-                       mtl >= 2.0 && < 2.3,
+                       mtl >= 2.0 && < 2.4,
                        diagrams-core >= 1.3 && < 1.6,
                        diagrams-lib >= 1.4.5 && < 1.5,
                        data-default-class < 0.2,

--- a/src/Diagrams/Backend/Postscript.hs
+++ b/src/Diagrams/Backend/Postscript.hs
@@ -8,6 +8,7 @@
 {-# LANGUAGE NoMonomorphismRestriction #-}
 {-# LANGUAGE TemplateHaskell           #-}
 {-# LANGUAGE TypeFamilies              #-}
+{-# LANGUAGE TypeOperators             #-}
 {-# LANGUAGE TypeSynonymInstances      #-}
 {-# LANGUAGE ViewPatterns              #-}
 -----------------------------------------------------------------------------

--- a/src/Graphics/Rendering/Postscript.hs
+++ b/src/Graphics/Rendering/Postscript.hs
@@ -86,6 +86,7 @@ import           Control.Applicative
 import           Data.Monoid                (mconcat, mempty)
 #endif
 import           Control.Lens               (Lens', makeLenses, use, (%=), (.=))
+import           Control.Monad
 import           Control.Monad.State.Strict
 import qualified Data.ByteString.Builder    as B
 import           Data.Char                  (isPrint, ord)


### PR DESCRIPTION
Also add `TypeOperators` extension to `Diagrams.Backend.Postscript` to avoid errors in future GHC due to `~` operator.