### PR TITLE
Fix exports and documentation

### DIFF
--- a/diagrams-postscript.cabal
+++ b/diagrams-postscript.cabal
@@ -46,7 +46,7 @@ Library
                        monoid-extras >= 0.3 && < 0.8,
                        semigroups >= 0.3.4 && < 0.21,
                        lens >= 4.0 && < 5.4,
-                       containers >= 0.3 && < 0.8,
+                       containers >= 0.3 && < 0.9,
                        hashable >= 1.1 && < 1.6
 
   default-language:    Haskell2010

--- a/src/Diagrams/Backend/Postscript.hs
+++ b/src/Diagrams/Backend/Postscript.hs
@@ -24,14 +24,17 @@
 -- type in the diagram type construction
 --
 -- > d :: Diagram Postscript
--- > d = ...
+-- > d = square 10
 --
 -- and render giving the @Postscript@ token
 --
--- > renderDia Postscript (PostscriptOptions "file.eps" (Width 400) EPS) d
+-- > renderDia' d (PostscriptOptions "file.eps" (mkWidth 400) EPS)
 --
--- This IO action will write the specified file.
+-- This IO action will write the specified file. If you prefer to generate
+-- an in-memory 'ByteString', use 'renderDia'.
 --
+-- Check "Diagrams.Backend.Postscript.CmdLine" for the command-line
+-- interface documentation (a great way to start using this package).
 -----------------------------------------------------------------------------
 module Diagrams.Backend.Postscript
 
@@ -40,11 +43,13 @@ module Diagrams.Backend.Postscript
   , B
 
     -- * Postscript-specific options
+    -- | #postscript-options#
     -- $PostscriptOptions
 
   , Options(..), psfileName, psSizeSpec, psOutputFormat
 
     -- * Postscript-supported output formats
+
   , OutputFormat(..)
 
   , renderDias
@@ -204,11 +209,15 @@ renderDias opts ds = case opts^.psOutputFormat of
       sizes   = map (specToSize 1 . view psSizeSpec . fst) optsdss
       V2 w h  = foldBy (liftA2 max) zero sizes
 
+-- | Check [Postscript-specific options](#postscript-options) for a
+-- description of the available options.
 renderDia' :: QDiagram Postscript V2 Double Any -> Options Postscript V2 Double -> IO ()
 renderDia' d o = do
   let b = renderDia Postscript o d
   withFile (o ^. psfileName) WriteMode $ \h -> B.hPutBuilder h b
 
+-- | Check [Postscript-specific options](#postscript-options) for a
+-- description of the available options.
 renderDias' :: [QDiagram Postscript V2 Double Any] -> Options Postscript V2 Double -> IO ()
 renderDias' ds o = renderDias o ds >> return ()
 

--- a/src/Diagrams/Backend/Postscript/CmdLine.hs
+++ b/src/Diagrams/Backend/Postscript/CmdLine.hs
@@ -73,7 +73,6 @@ module Diagrams.Backend.Postscript.CmdLine
       ) where
 
 import qualified Data.ByteString.Builder     as B
-import           System.IO                   (IOMode (..), withFile)
 
 import           Diagrams.Backend.CmdLine
 import           Diagrams.Backend.Postscript
@@ -163,16 +162,6 @@ chooseRender opts renderer =
 
            renderer (PostscriptOptions (opts^.output) sizeSpec outfmt)
        | otherwise -> putStrLn $ "Unknown file type: " ++ last ps
-
-renderDias' :: [QDiagram Postscript V2 Double Any] -> Options Postscript V2 Double -> IO ()
-renderDias' ds o = renderDias o ds >> return ()
-
-renderDia' :: QDiagram Postscript V2 Double Any -> Options Postscript V2 Double -> IO ()
-renderDia' d o = do
-  let b = renderDia Postscript o d
-  withFile (o ^. psfileName) WriteMode $ \h -> B.hPutBuilder h b
-
-
 
 -- | @multiMain@ is like 'defaultMain', except instead of a single
 --   diagram it takes a list of diagrams paired with names as input.


### PR DESCRIPTION
Fixes #36 

Two commits for easier reviewing, if needed I can squash before the merge.

Notice we are now exporting `renderDia'` and `renderDias'`, but **not** `renderDia`.
I wonder whether that is correct (it seems so to me, but I am not sure).